### PR TITLE
Fix Symfony 5 & doctrine bundle 2 support

### DIFF
--- a/Controller/CookieConsentController.php
+++ b/Controller/CookieConsentController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\Translation\Translator;
 
 class CookieConsentController
 {
@@ -44,7 +44,7 @@ class CookieConsentController
     private $cookieConsentPosition;
 
     /**
-     * @var TranslatorInterface
+     * @var Translator
      */
     private $translator;
 
@@ -54,7 +54,7 @@ class CookieConsentController
         CookieChecker $cookieChecker,
         string $cookieConsentTheme,
         string $cookieConsentPosition,
-        TranslatorInterface $translator
+        Translator $translator
     ) {
         $this->twigEnvironment       = $twigEnvironment;
         $this->formFactory           = $formFactory;

--- a/Controller/CookieConsentController.php
+++ b/Controller/CookieConsentController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class CookieConsentController
 {

--- a/Cookie/CookieLogger.php
+++ b/Cookie/CookieLogger.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace ConnectHolland\CookieConsentBundle\Cookie;
 
 use ConnectHolland\CookieConsentBundle\Entity\CookieConsentLog;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class CookieLogger
@@ -26,7 +26,7 @@ class CookieLogger
      */
     private $request;
 
-    public function __construct(RegistryInterface $registry, ?Request $request)
+    public function __construct(ManagerRegistry $registry, ?Request $request)
     {
         $this->entityManager = $registry->getManagerForClass(CookieConsentLog::class);
         $this->request       = $request;

--- a/EventSubscriber/CookieConsentFormSubscriber.php
+++ b/EventSubscriber/CookieConsentFormSubscriber.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -56,8 +58,12 @@ class CookieConsentFormSubscriber implements EventSubscriberInterface
     /**
      * Checks if form has been submitted and saves users preferences in cookies by calling the CookieHandler.
      */
-    public function onResponse(ResponseEvent $event): void
+    public function onResponse(KernelEvent $event): void
     {
+        if ($event instanceof FilterResponseEvent === false && $event instanceof ResponseEvent) {
+            throw new \RuntimeException('No ReponseEvent class found');
+        }
+
         $request  = $event->getRequest();
         $response = $event->getResponse();
 

--- a/EventSubscriber/CookieConsentFormSubscriber.php
+++ b/EventSubscriber/CookieConsentFormSubscriber.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class CookieConsentFormSubscriber implements EventSubscriberInterface
@@ -56,7 +56,7 @@ class CookieConsentFormSubscriber implements EventSubscriberInterface
     /**
      * Checks if form has been submitted and saves users preferences in cookies by calling the CookieHandler.
      */
-    public function onResponse(FilterResponseEvent $event): void
+    public function onResponse(ResponseEvent $event): void
     {
         $request  = $event->getRequest();
         $response = $event->getResponse();

--- a/Tests/Controller/CookieConsentControllerTest.php
+++ b/Tests/Controller/CookieConsentControllerTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\Translator;
 
 class CookieConsentControllerTest extends TestCase
 {
@@ -52,7 +52,7 @@ class CookieConsentControllerTest extends TestCase
         $this->templating              = $this->createMock(\Twig_Environment::class);
         $this->formFactory             = $this->createMock(FormFactoryInterface::class);
         $this->cookieChecker           = $this->createMock(CookieChecker::class);
-        $this->translator              = $this->createMock(TranslatorInterface::class);
+        $this->translator              = $this->createMock(Translator::class);
         $this->cookieConsentController = new CookieConsentController($this->templating, $this->formFactory, $this->cookieChecker, 'dark', 'top', $this->translator);
     }
 

--- a/Tests/Cookie/CookieLoggerTest.php
+++ b/Tests/Cookie/CookieLoggerTest.php
@@ -11,10 +11,10 @@ namespace ConnectHolland\CookieConsentBundle\Tests\Cookie;
 
 use ConnectHolland\CookieConsentBundle\Cookie\CookieLogger;
 use ConnectHolland\CookieConsentBundle\Entity\CookieConsentLog;
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class CookieLoggerTest extends TestCase
@@ -36,7 +36,7 @@ class CookieLoggerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->registry      = $this->createMock(RegistryInterface::class);
+        $this->registry      = $this->createMock(ManagerRegistry::class);
         $this->request       = $this->createMock(Request::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
 

--- a/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
+++ b/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -54,7 +55,7 @@ class CookieConsentFormSubscriberTest extends TestCase
         $request  = new Request();
         $response = new Response();
 
-        $event = $this->createMock(ResponseEvent::class);
+        $event = $this->getMockResponseEvent();
         $event
             ->expects($this->once())
             ->method('getRequest')
@@ -97,7 +98,7 @@ class CookieConsentFormSubscriberTest extends TestCase
         $request  = new Request();
         $response = new Response();
 
-        $event = $this->createMock(ResponseEvent::class);
+        $event = $this->getMockResponseEvent();
         $event
             ->expects($this->once())
             ->method('getRequest')
@@ -133,5 +134,15 @@ class CookieConsentFormSubscriberTest extends TestCase
 
         $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, false);
         $cookieConsentFormSubscriber->onResponse($event);
+    }
+
+    private function getMockResponseEvent(): MockObject
+    {
+        if (class_exists(ReponseEvent::class)) {
+            return $this->createMock(ResponseEvent::class);
+        } else {
+            // Support for Symfony 3.4 & < 4.3
+            return $this->createMock(FilterResponseEvent::class);
+        }
     }
 }

--- a/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
+++ b/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class CookieConsentFormSubscriberTest extends TestCase
@@ -54,7 +54,7 @@ class CookieConsentFormSubscriberTest extends TestCase
         $request  = new Request();
         $response = new Response();
 
-        $event = $this->createMock(FilterResponseEvent::class);
+        $event = $this->createMock(ResponseEvent::class);
         $event
             ->expects($this->once())
             ->method('getRequest')
@@ -97,7 +97,7 @@ class CookieConsentFormSubscriberTest extends TestCase
         $request  = new Request();
         $response = new Response();
 
-        $event = $this->createMock(FilterResponseEvent::class);
+        $event = $this->createMock(ResponseEvent::class);
         $event
             ->expects($this->once())
             ->method('getRequest')

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
         "symfony/templating": "^3.4 || ^4.2 || ^5.0",
         "symfony/translation": "^3.4 || ^4.2 || ^5.0",
+        "symfony/translation-contracts": "^2.0",
         "symfony/twig-bridge": "^3.4 || ^4.2 || ^5.0",
         "symfony/twig-bundle": "^3.4 || ^4.2 || ^5.0",
         "twig/twig": "^2.6"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
         "symfony/templating": "^3.4 || ^4.2 || ^5.0",
         "symfony/translation": "^3.4 || ^4.2 || ^5.0",
-        "symfony/translation-contracts": "^2.0",
         "symfony/twig-bridge": "^3.4 || ^4.2 || ^5.0",
         "symfony/twig-bundle": "^3.4 || ^4.2 || ^5.0",
         "twig/twig": "^2.6"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Symfony bundle for implementing Cookie Consent to comply to AVG/GDPR.",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "doctrine/annotations": "^1.6",
         "doctrine/doctrine-bundle": "^1.10 || ^2.0",
         "doctrine/orm": "^2.5",
@@ -19,8 +19,7 @@
         "symfony/translation": "^3.4 || ^4.2 || ^5.0",
         "symfony/twig-bridge": "^3.4 || ^4.2 || ^5.0",
         "symfony/twig-bundle": "^3.4 || ^4.2 || ^5.0",
-        "twig/twig": "^2.6",
-        "wa72/htmlpagedom": "^1.3"
+        "twig/twig": "^2.6"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",


### PR DESCRIPTION
- Replace namespace of Symfony\Bridge\Doctrine\RegistryInterface with Doctrine\Common\Persistence\ManagerRegistry
- Raise minimum php requirement to php 7.2 as 7.1 is EOL
- Remove wa72/htmlpagedom dependency
- Fix KernelResponse event class