### PR TITLE
Make it possible to set HttpOnly on cookies

### DIFF
--- a/Cookie/CookieHandler.php
+++ b/Cookie/CookieHandler.php
@@ -30,26 +30,26 @@ class CookieHandler
     /**
      * Save chosen cookie categories in cookies.
      */
-    public function save(array $categories, string $key): void
+    public function save(array $categories, string $key, bool $httpOnly): void
     {
-        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_NAME, date('r'));
-        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_KEY_NAME, $key);
+        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_NAME, date('r'), $httpOnly);
+        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_KEY_NAME, $key, $httpOnly);
 
         foreach ($categories as $category => $permitted) {
-            $this->saveCookie(CookieNameEnum::getCookieCategoryName($category), $permitted);
+            $this->saveCookie(CookieNameEnum::getCookieCategoryName($category), $permitted, $httpOnly);
         }
     }
 
     /**
      * Add cookie to response headers.
      */
-    protected function saveCookie(string $name, string $value): void
+    protected function saveCookie(string $name, string $value, bool $httpOnly): void
     {
         $expirationDate = new DateTime();
         $expirationDate->add(new DateInterval('P1Y'));
 
         $this->response->headers->setCookie(
-            new Cookie($name, $value, $expirationDate, '/', null, null, true, true)
+            new Cookie($name, $value, $expirationDate, '/', null, null, $httpOnly, true)
         );
     }
 }

--- a/Cookie/CookieHandler.php
+++ b/Cookie/CookieHandler.php
@@ -18,38 +18,38 @@ use Symfony\Component\HttpFoundation\Response;
 class CookieHandler
 {
     /**
-     * @var Response
+     * @var bool
      */
-    private $response;
+    private $httpOnly;
 
-    public function __construct(Response $response)
+    public function __construct(bool $httpOnly)
     {
-        $this->response = $response;
+        $this->httpOnly = $httpOnly;
     }
 
     /**
      * Save chosen cookie categories in cookies.
      */
-    public function save(array $categories, string $key, bool $httpOnly): void
+    public function save(array $categories, string $key, Response $response): void
     {
-        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_NAME, date('r'), $httpOnly);
-        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_KEY_NAME, $key, $httpOnly);
+        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_NAME, date('r'), $response);
+        $this->saveCookie(CookieNameEnum::COOKIE_CONSENT_KEY_NAME, $key, $response);
 
         foreach ($categories as $category => $permitted) {
-            $this->saveCookie(CookieNameEnum::getCookieCategoryName($category), $permitted, $httpOnly);
+            $this->saveCookie(CookieNameEnum::getCookieCategoryName($category), $permitted, $response);
         }
     }
 
     /**
      * Add cookie to response headers.
      */
-    protected function saveCookie(string $name, string $value, bool $httpOnly): void
+    protected function saveCookie(string $name, string $value, Response $response): void
     {
         $expirationDate = new DateTime();
         $expirationDate->add(new DateInterval('P1Y'));
 
-        $this->response->headers->setCookie(
-            new Cookie($name, $value, $expirationDate, '/', null, null, $httpOnly, true)
+        $response->headers->setCookie(
+            new Cookie($name, $value, $expirationDate, '/', null, null, $this->httpOnly, true)
         );
     }
 }

--- a/Cookie/CookieLogger.php
+++ b/Cookie/CookieLogger.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace ConnectHolland\CookieConsentBundle\Cookie;
 
 use ConnectHolland\CookieConsentBundle\Entity\CookieConsentLog;
-use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 
 class CookieLogger

--- a/DependencyInjection/CHCookieConsentExtension.php
+++ b/DependencyInjection/CHCookieConsentExtension.php
@@ -27,6 +27,7 @@ class CHCookieConsentExtension extends Extension
         $container->setParameter('ch_cookie_consent.use_logger', $config['use_logger']);
         $container->setParameter('ch_cookie_consent.position', $config['position']);
         $container->setParameter('ch_cookie_consent.simplified', $config['simplified']);
+        $container->setParameter('ch_cookie_consent.http_only', $config['http_only']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,6 +47,9 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('simplified')
                     ->defaultFalse()
                 ->end()
+                ->booleanNode('http_only')
+                    ->defaultTrue()
+                ->end()
             ->end()
         ;
 

--- a/EventSubscriber/CookieConsentFormSubscriber.php
+++ b/EventSubscriber/CookieConsentFormSubscriber.php
@@ -41,11 +41,17 @@ class CookieConsentFormSubscriber implements EventSubscriberInterface
      */
     private $useLogger;
 
-    public function __construct(FormFactoryInterface $formFactory, CookieLogger $cookieLogger, bool $useLogger)
+    /**
+     * @var bool
+     */
+    private $httpOnly;
+
+    public function __construct(FormFactoryInterface $formFactory, CookieLogger $cookieLogger, bool $useLogger, bool $httpOnly)
     {
         $this->formFactory  = $formFactory;
         $this->cookieLogger = $cookieLogger;
         $this->useLogger    = $useLogger;
+        $this->httpOnly     = $httpOnly;
     }
 
     public static function getSubscribedEvents(): array
@@ -83,7 +89,7 @@ class CookieConsentFormSubscriber implements EventSubscriberInterface
         $cookieConsentKey = $this->getCookieConsentKey($request);
 
         $cookieHandler = new CookieHandler($response);
-        $cookieHandler->save($categories, $cookieConsentKey);
+        $cookieHandler->save($categories, $cookieConsentKey, $this->httpOnly);
 
         if ($this->useLogger) {
             $this->cookieLogger->log($categories, $cookieConsentKey);

--- a/EventSubscriber/CookieConsentFormSubscriber.php
+++ b/EventSubscriber/CookieConsentFormSubscriber.php
@@ -37,21 +37,21 @@ class CookieConsentFormSubscriber implements EventSubscriberInterface
     private $cookieLogger;
 
     /**
-     * @var bool
+     * @var CookieHandler
      */
-    private $useLogger;
+    private $cookieHandler;
 
     /**
      * @var bool
      */
-    private $httpOnly;
+    private $useLogger;
 
-    public function __construct(FormFactoryInterface $formFactory, CookieLogger $cookieLogger, bool $useLogger, bool $httpOnly)
+    public function __construct(FormFactoryInterface $formFactory, CookieLogger $cookieLogger, CookieHandler $cookieHandler, bool $useLogger)
     {
-        $this->formFactory  = $formFactory;
-        $this->cookieLogger = $cookieLogger;
-        $this->useLogger    = $useLogger;
-        $this->httpOnly     = $httpOnly;
+        $this->formFactory   = $formFactory;
+        $this->cookieLogger  = $cookieLogger;
+        $this->cookieHandler = $cookieHandler;
+        $this->useLogger     = $useLogger;
     }
 
     public static function getSubscribedEvents(): array
@@ -88,8 +88,7 @@ class CookieConsentFormSubscriber implements EventSubscriberInterface
     {
         $cookieConsentKey = $this->getCookieConsentKey($request);
 
-        $cookieHandler = new CookieHandler($response);
-        $cookieHandler->save($categories, $cookieConsentKey, $this->httpOnly);
+        $this->cookieHandler->save($categories, $cookieConsentKey, $response);
 
         if ($this->useLogger) {
             $this->cookieLogger->log($categories, $cookieConsentKey);

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ch_cookie_consent:
     use_logger: true # Logs user actions to database
     position: 'top' # top, bottom
     simplified: false # When set to true the user can only deny or accept all cookies at once
+    http_only: true # Sets HttpOnly on cookies
 ```
 
 ## Usage

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -11,6 +11,7 @@ services:
             $useLogger: '%ch_cookie_consent.use_logger%'
             $cookieConsentPosition: '%ch_cookie_consent.position%'
             $cookieConsentSimplified: '%ch_cookie_consent.simplified%'
+            $httpOnly: '%ch_cookie_consent.http_only%'
 
     ConnectHolland\CookieConsentBundle\:
         resource: '../../'

--- a/Tests/Cookie/CookieHandlerTest.php
+++ b/Tests/Cookie/CookieHandlerTest.php
@@ -38,15 +38,11 @@ class CookieHandlerTest extends TestCase
     }
 
     /**
-     * Test CookieHandler:save.
+     * Test CookieHandler:save with httpOnly true.
      */
     public function testSave(): void
     {
-        $this->cookieHandler->save([
-            'analytics'    => 'true',
-            'social_media' => 'true',
-            'tracking'     => 'false',
-        ], 'key-test', $this->response);
+        $this->saveCookieHandler($this->cookieHandler);
 
         $cookies = $this->response->headers->getCookies();
 
@@ -66,5 +62,28 @@ class CookieHandlerTest extends TestCase
         $this->assertSame('Cookie_Category_tracking', $cookies[4]->getName());
         $this->assertSame('false', $cookies[4]->getValue());
         $this->assertSame(true, $cookies[4]->isHttpOnly());
+    }
+
+    /**
+     * Test CookieHandler:save with httpOnly false.
+     */
+    public function testCookieHanlderHttpOnlyIsFalse(): void
+    {
+        $this->httpOnly       = false;
+        $this->saveCookieHandler(new CookieHandler($this->httpOnly));
+        $cookies = $this->response->headers->getCookies();
+        $this->assertSame(false, $cookies[4]->isHttpOnly());
+    }
+
+    /**
+     * Save CookieHandler.
+     */
+    public function saveCookieHandler(CookieHandler $cookieHandler): void
+    {
+        $cookieHandler->save([
+            'analytics'    => 'true',
+            'social_media' => 'true',
+            'tracking'     => 'false',
+        ], 'key-test', $this->response);
     }
 }

--- a/Tests/Cookie/CookieHandlerTest.php
+++ b/Tests/Cookie/CookieHandlerTest.php
@@ -20,29 +20,17 @@ class CookieHandlerTest extends TestCase
      */
     private $response;
 
-    /**
-     * @var bool
-     */
-    private $httpOnly;
-
-    /**
-     * @var CookieHandler
-     */
-    private $cookieHandler;
-
     public function setUp(): void
     {
-        $this->response       = new Response();
-        $this->httpOnly       = true;
-        $this->cookieHandler  = new CookieHandler($this->httpOnly);
+        $this->response = new Response();
     }
 
     /**
-     * Test CookieHandler:save with httpOnly true.
+     * Test CookieHandler:save.
      */
     public function testSave(): void
     {
-        $this->saveCookieHandler($this->cookieHandler);
+        $this->saveCookieHandler(true);
 
         $cookies = $this->response->headers->getCookies();
 
@@ -61,25 +49,35 @@ class CookieHandlerTest extends TestCase
 
         $this->assertSame('Cookie_Category_tracking', $cookies[4]->getName());
         $this->assertSame('false', $cookies[4]->getValue());
-        $this->assertSame(true, $cookies[4]->isHttpOnly());
     }
 
     /**
      * Test CookieHandler:save with httpOnly false.
      */
-    public function testCookieHanlderHttpOnlyIsFalse(): void
+    public function testCookieHandlerHttpOnlyIsFalse(): void
     {
-        $this->httpOnly       = false;
-        $this->saveCookieHandler(new CookieHandler($this->httpOnly));
+        $this->saveCookieHandler(false);
         $cookies = $this->response->headers->getCookies();
         $this->assertSame(false, $cookies[4]->isHttpOnly());
     }
 
     /**
+     * Test CookieHandler:save with httpOnly true.
+     */
+    public function testCookieHandlerHttpOnlyIsTrue(): void
+    {
+        $this->saveCookieHandler(true);
+        $cookies = $this->response->headers->getCookies();
+        $this->assertSame(true, $cookies[4]->isHttpOnly());
+    }
+
+    /**
      * Save CookieHandler.
      */
-    public function saveCookieHandler(CookieHandler $cookieHandler): void
+    public function saveCookieHandler(bool $httpOnly): void
     {
+        $cookieHandler = new CookieHandler($httpOnly);
+
         $cookieHandler->save([
             'analytics'    => 'true',
             'social_media' => 'true',

--- a/Tests/Cookie/CookieHandlerTest.php
+++ b/Tests/Cookie/CookieHandlerTest.php
@@ -21,6 +21,11 @@ class CookieHandlerTest extends TestCase
     private $response;
 
     /**
+     * @var bool
+     */
+    private $httpOnly;
+
+    /**
      * @var CookieHandler
      */
     private $cookieHandler;
@@ -28,7 +33,8 @@ class CookieHandlerTest extends TestCase
     public function setUp(): void
     {
         $this->response       = new Response();
-        $this->cookieHandler  = new CookieHandler($this->response);
+        $this->httpOnly       = true;
+        $this->cookieHandler  = new CookieHandler($this->httpOnly);
     }
 
     /**
@@ -40,7 +46,7 @@ class CookieHandlerTest extends TestCase
             'analytics'    => 'true',
             'social_media' => 'true',
             'tracking'     => 'false',
-        ], 'key-test', true);
+        ], 'key-test', $this->response);
 
         $cookies = $this->response->headers->getCookies();
 

--- a/Tests/Cookie/CookieHandlerTest.php
+++ b/Tests/Cookie/CookieHandlerTest.php
@@ -40,7 +40,7 @@ class CookieHandlerTest extends TestCase
             'analytics'    => 'true',
             'social_media' => 'true',
             'tracking'     => 'false',
-        ], 'key-test');
+        ], 'key-test', true);
 
         $cookies = $this->response->headers->getCookies();
 
@@ -59,5 +59,6 @@ class CookieHandlerTest extends TestCase
 
         $this->assertSame('Cookie_Category_tracking', $cookies[4]->getName());
         $this->assertSame('false', $cookies[4]->getValue());
+        $this->assertSame(true, $cookies[4]->isHttpOnly());
     }
 }

--- a/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
+++ b/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace ConnectHolland\CookieConsentBundle\Tests\EventSubscriber;
 
+use ConnectHolland\CookieConsentBundle\Cookie\CookieHandler;
 use ConnectHolland\CookieConsentBundle\Cookie\CookieLogger;
 use ConnectHolland\CookieConsentBundle\EventSubscriber\CookieConsentFormSubscriber;
 use ConnectHolland\CookieConsentBundle\Form\CookieConsentType;
@@ -36,10 +37,16 @@ class CookieConsentFormSubscriberTest extends TestCase
      */
     private $cookieLogger;
 
+    /**
+     * @var MockObject
+     */
+    private $cookieHandler;
+
     public function setUp(): void
     {
-        $this->formFactoryInterface = $this->createMock(FormFactoryInterface::class);
-        $this->cookieLogger         = $this->createMock(CookieLogger::class);
+        $this->formFactoryInterface  = $this->createMock(FormFactoryInterface::class);
+        $this->cookieLogger          = $this->createMock(CookieLogger::class);
+        $this->cookieHandler         = $this->createMock(CookieHandler::class);
     }
 
     public function testGetSubscribedEvents(): void
@@ -48,7 +55,7 @@ class CookieConsentFormSubscriberTest extends TestCase
            KernelEvents::RESPONSE => ['onResponse'],
         ];
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, true, false);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, $this->cookieHandler, true);
         $this->assertSame($expectedEvents, $cookieConsentFormSubscriber->getSubscribedEvents());
     }
 
@@ -82,7 +89,7 @@ class CookieConsentFormSubscriberTest extends TestCase
             ->expects($this->once())
             ->method('log');
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, true, false);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, $this->cookieHandler, true);
         $cookieConsentFormSubscriber->onResponse($event);
     }
 
@@ -116,7 +123,7 @@ class CookieConsentFormSubscriberTest extends TestCase
             ->expects($this->never())
             ->method('log');
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, false, false);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, $this->cookieHandler, false);
         $cookieConsentFormSubscriber->onResponse($event);
     }
 
@@ -125,7 +132,7 @@ class CookieConsentFormSubscriberTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('No ResponseEvent class found');
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, false, false);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, $this->cookieHandler, false);
         $cookieConsentFormSubscriber->onResponse($this->createMock(KernelEvent::class));
     }
 

--- a/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
+++ b/Tests/EventSubscriber/CookieConsentFormSubscriberTest.php
@@ -48,7 +48,7 @@ class CookieConsentFormSubscriberTest extends TestCase
            KernelEvents::RESPONSE => ['onResponse'],
         ];
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, true);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, true, false);
         $this->assertSame($expectedEvents, $cookieConsentFormSubscriber->getSubscribedEvents());
     }
 
@@ -82,7 +82,7 @@ class CookieConsentFormSubscriberTest extends TestCase
             ->expects($this->once())
             ->method('log');
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, true);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, true, false);
         $cookieConsentFormSubscriber->onResponse($event);
     }
 
@@ -116,7 +116,7 @@ class CookieConsentFormSubscriberTest extends TestCase
             ->expects($this->never())
             ->method('log');
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, false);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, false, false);
         $cookieConsentFormSubscriber->onResponse($event);
     }
 
@@ -125,7 +125,7 @@ class CookieConsentFormSubscriberTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('No ResponseEvent class found');
 
-        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, false);
+        $cookieConsentFormSubscriber = new CookieConsentFormSubscriber($this->formFactoryInterface, $this->cookieLogger, false, false);
         $cookieConsentFormSubscriber->onResponse($this->createMock(KernelEvent::class));
     }
 


### PR DESCRIPTION
When http_only is not set in the config (or on true), HttpOnly is still set:
![image](https://user-images.githubusercontent.com/11276046/99520486-741e3480-2993-11eb-908b-bc6f406a4f98.png)
When http_only is set false in the config, HttpOnly is not set:
![image](https://user-images.githubusercontent.com/11276046/99520669-adef3b00-2993-11eb-966d-5c6d8438b887.png)
