### PR TITLE
Uses offsetParent instead of checking specific CSS values for hidden details

### DIFF
--- a/Resources/public/js/cookie_consent.js
+++ b/Resources/public/js/cookie_consent.js
@@ -54,10 +54,10 @@ document.addEventListener("DOMContentLoaded", function() {
 
     if (cookieConsentCategoryDetails && cookieConsentCategoryDetailsToggle) {
         cookieConsentCategoryDetailsToggle.addEventListener('click', function() {
-            var detailsIsHidden = cookieConsentCategoryDetails.style.display !== 'block';
-            cookieConsentCategoryDetails.style.display = detailsIsHidden ? 'block' : 'none';
-            cookieConsentCategoryDetailsToggle.querySelector('.ch-cookie-consent__toggle-details-hide').style.display = detailsIsHidden ? 'block' : 'none';
-            cookieConsentCategoryDetailsToggle.querySelector('.ch-cookie-consent__toggle-details-show').style.display = detailsIsHidden ? 'none' : 'block';
+            var detailsIsHidden = cookieConsentCategoryDetails.offsetParent !== null;
+            cookieConsentCategoryDetails.style.display = detailsIsHidden ? 'none' : 'block';
+            cookieConsentCategoryDetailsToggle.querySelector('.ch-cookie-consent__toggle-details-hide').style.display = detailsIsHidden ? 'none' : 'block';
+            cookieConsentCategoryDetailsToggle.querySelector('.ch-cookie-consent__toggle-details-show').style.display = detailsIsHidden ? 'block' : 'none';
         });
     }
 });


### PR DESCRIPTION
Appears to be a more stable solution https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent