### PR TITLE
Fix some HTML5 validation

### DIFF
--- a/Resources/views/cookie_consent.html.twig
+++ b/Resources/views/cookie_consent.html.twig
@@ -1,7 +1,7 @@
 {% form_theme form '@CHCookieConsent/form/cookie_consent_theme.html.twig' %}
 
 {% block script %}
-    <script type="text/javascript" src="{{ asset('bundles/chcookieconsent/js/cookie_consent.js') }}"></script>
+    <script src="{{ asset('bundles/chcookieconsent/js/cookie_consent.js') }}"></script>
 {% endblock %}
 
 <div class="ch-cookie-consent ch-cookie-consent--{{ theme }}-theme ch-cookie-consent--{{ position }} {% if simplified %}ch-cookie-consent--simplified{% endif %}">

--- a/Resources/views/cookie_consent_styling.html.twig
+++ b/Resources/views/cookie_consent_styling.html.twig
@@ -1,3 +1,3 @@
 {% block style %}
-    <link rel="stylesheet" href="{{ asset('bundles/chcookieconsent/css/cookie_consent.css') }}"/>
+    <link rel="stylesheet" href="{{ asset('bundles/chcookieconsent/css/cookie_consent.css') }}">
 {% endblock %}


### PR DESCRIPTION
Removed trailing slashes, [source](https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-in-void-element-start-tags-do-not-mark-the-start-tags-as-self-closing).

Removed script type declaration:

> Warning: The type attribute is unnecessary for JavaScript resources.